### PR TITLE
[bug fix] fix base64 image support 

### DIFF
--- a/reportbro/elements.py
+++ b/reportbro/elements.py
@@ -78,6 +78,9 @@ class ImageElement(DocElement):
 
         # only load image if available
         if self.image_key:
+            if self.image_key.startswith('data:image/'):
+                self.image = self.image_key
+                self.image_key = 'image_' + str(self.id)
             self.report.load_image(self.image_key, ctx, self.id, self.source, self.image)
 
         if self.link:

--- a/reportbro/reportbro.py
+++ b/reportbro/reportbro.py
@@ -353,6 +353,9 @@ class ImageData:
         if img_data_b64 is None and not image_uri and self.image_data is None and image_file:
             # static image base64 encoded within image element
             img_data_b64 = image_file
+        
+        elif img_data_b64 is None and self.image_data is None and image_file == image_uri:
+            img_data_b64 = image_file
 
         if img_data_b64:
             m = re.match('^data:image/(.+);base64,', img_data_b64)


### PR DESCRIPTION
In the older version, passing base64-encoded image values in the data parameter was not supported. Our code analysis revealed that only image URLs were supported. We have now implemented modifications to add base64 image support.

fixed this error:  `errorMsgInvalidImageSource`